### PR TITLE
fix(download-server): fall back from deprecated Google OAuth endpoint

### DIFF
--- a/download-server.sh
+++ b/download-server.sh
@@ -78,6 +78,7 @@ print_deprecation_warning() {
   echo "WARNING: The Google OAuth token endpoint '$legacyTokenUrl' is deprecated by Google." >&2
   echo "         This script tries it first for backward compatibility and falls back to '$currentTokenUrl' when it cannot be reached." >&2
   echo "         Please make sure the host 'oauth2.googleapis.com' is allowed in your network/firewall policy." >&2
+  echo "         For more information: https://docs.appcircle.io/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/network-access" >&2
 }
 
 check_cred_json() {

--- a/download-server.sh
+++ b/download-server.sh
@@ -79,6 +79,8 @@ print_deprecation_warning() {
   echo "         This script tries it first for backward compatibility and falls back to '$currentTokenUrl' when it cannot be reached." >&2
   echo "         Please make sure the host 'oauth2.googleapis.com' is allowed in your network/firewall policy." >&2
   echo "         For more information: https://docs.appcircle.io/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/network-access#if-you-are-an-enterprise-licensed-or-poc-customer-appcircle-server-zip-package" >&2
+  echo ""
+  echo ""
 }
 
 check_cred_json() {

--- a/download-server.sh
+++ b/download-server.sh
@@ -4,8 +4,19 @@ set -eou pipefail
 credJsonPath="./cred.json"
 gcloudAccessToken=""
 userId=""
-version="0.1.2"
+version="0.1.3"
 preferedPackageVersion=""
+
+# Google OAuth 2.0 token endpoints.
+# The legacy endpoint is deprecated by Google but is still the host that existing
+# self-hosted customers have allow-listed in their network policy. To stay
+# backward compatible we try the legacy endpoint first and fall back to the
+# current endpoint only when the legacy one cannot be reached.
+legacyTokenUrl="https://www.googleapis.com/oauth2/v4/token"
+currentTokenUrl="https://oauth2.googleapis.com/token"
+# Holds the audience used for the JWT currently being signed. It must always
+# match the token endpoint the assertion is sent to, otherwise Google rejects it.
+tokenAud="$legacyTokenUrl"
 
 version_info() {
   echo "Appcircle Server Package Downloader $version"
@@ -63,6 +74,12 @@ parse_arguments() {
   done
 }
 
+print_deprecation_warning() {
+  echo "WARNING: The Google OAuth token endpoint '$legacyTokenUrl' is deprecated by Google." >&2
+  echo "         This script tries it first for backward compatibility and falls back to '$currentTokenUrl' when it cannot be reached." >&2
+  echo "         Please make sure the host 'oauth2.googleapis.com' is allowed in your network/firewall policy." >&2
+}
+
 check_cred_json() {
   if ! [[ -f $credJsonPath ]]; then
     echo "'cred.json' file doesn't exist in '$(pwd)'."
@@ -85,12 +102,41 @@ extract_user_id() {
 authenticate_gcs() {
   credJsonPath=$1
   scope=$2
-  create_jwt_google_cloud "$credJsonPath" "$scope"
-  jwtToken="${jwtGoogleCloud}"
-  gcloudAccessToken=$(curl -s -X POST https://www.googleapis.com/oauth2/v4/token \
-    --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer' \
-    --data-urlencode "assertion=$jwtToken" |
-    grep -oP '"access_token":"\K[^"]+')
+
+  gcloudAccessToken=""
+  for tokenUrl in "$legacyTokenUrl" "$currentTokenUrl"; do
+    # The JWT 'aud' claim must equal the token endpoint the assertion is posted
+    # to, so the JWT is rebuilt and re-signed for each endpoint we try.
+    tokenAud="$tokenUrl"
+    create_jwt_google_cloud "$credJsonPath" "$scope"
+    jwtToken="${jwtGoogleCloud}"
+
+    set +e
+    tokenResponse=$(curl -s --connect-timeout 30 -X POST "$tokenUrl" \
+      --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer' \
+      --data-urlencode "assertion=$jwtToken")
+    curlStatus=$?
+    set -e
+
+    if [[ "$curlStatus" -ne 0 ]]; then
+      echo "WARNING: Could not reach Google OAuth token endpoint '$tokenUrl' (curl exit $curlStatus). Trying the next endpoint if available." >&2
+      continue
+    fi
+
+    set +e
+    gcloudAccessToken=$(echo "$tokenResponse" | grep -oP '"access_token":"\K[^"]+')
+    set -e
+    if [[ -n "$gcloudAccessToken" ]]; then
+      break
+    fi
+    echo "WARNING: Google OAuth token endpoint '$tokenUrl' did not return an access token. Trying the next endpoint if available." >&2
+  done
+
+  if [[ -z "$gcloudAccessToken" ]]; then
+    echo "Failed to obtain a Google Cloud access token from both the legacy ('$legacyTokenUrl') and current ('$currentTokenUrl') OAuth endpoints."
+    echo "Please verify your 'cred.json' and that one of these hosts is reachable from your network."
+    exit 1
+  fi
 }
 
 download_appcircle_server_package() {
@@ -151,7 +197,7 @@ create_jwt_google_cloud() {
 {
     "iss": "$saEmail",
     "scope": "$scope",
-    "aud": "https://www.googleapis.com/oauth2/v4/token",
+    "aud": "$tokenAud",
     "exp": $exp,
     "iat": $iat
 }
@@ -173,6 +219,7 @@ base64stream() {
 main() {
   parse_arguments "$@"
   suffix_version_option
+  print_deprecation_warning
   echo "Downloading the Appcircle server zip package..."
   check_cred_json
   extract_user_id

--- a/download-server.sh
+++ b/download-server.sh
@@ -78,7 +78,7 @@ print_deprecation_warning() {
   echo "WARNING: The Google OAuth token endpoint '$legacyTokenUrl' is deprecated by Google." >&2
   echo "         This script tries it first for backward compatibility and falls back to '$currentTokenUrl' when it cannot be reached." >&2
   echo "         Please make sure the host 'oauth2.googleapis.com' is allowed in your network/firewall policy." >&2
-  echo "         For more information: https://docs.appcircle.io/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/network-access" >&2
+  echo "         For more information: https://docs.appcircle.io/self-hosted-appcircle/install-server/linux-package/configure-server/integrations-and-access/network-access#if-you-are-an-enterprise-licensed-or-poc-customer-appcircle-server-zip-package" >&2
 }
 
 check_cred_json() {

--- a/download-server.sh
+++ b/download-server.sh
@@ -130,6 +130,7 @@ authenticate_gcs() {
     gcloudAccessToken=$(echo "$tokenResponse" | grep -oP '"access_token":"\K[^"]+')
     set -e
     if [[ -n "$gcloudAccessToken" ]]; then
+      echo "Authenticated with Google using OAuth token endpoint '$tokenUrl'."
       break
     fi
     echo "WARNING: Google OAuth token endpoint '$tokenUrl' did not return an access token. Trying the next endpoint if available." >&2

--- a/download-server.sh
+++ b/download-server.sh
@@ -115,7 +115,7 @@ authenticate_gcs() {
     jwtToken="${jwtGoogleCloud}"
 
     set +e
-    tokenResponse=$(curl -s --connect-timeout 30 -X POST "$tokenUrl" \
+    tokenResponse=$(curl -sS --connect-timeout 30 --max-time 60 -X POST "$tokenUrl" \
       --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer' \
       --data-urlencode "assertion=$jwtToken")
     curlStatus=$?
@@ -127,7 +127,7 @@ authenticate_gcs() {
     fi
 
     set +e
-    gcloudAccessToken=$(echo "$tokenResponse" | grep -oP '"access_token":"\K[^"]+')
+    gcloudAccessToken=$(echo "$tokenResponse" | grep -oP '"access_token"\s*:\s*"\K[^"]+')
     set -e
     if [[ -n "$gcloudAccessToken" ]]; then
       echo "Authenticated with Google using OAuth token endpoint '$tokenUrl'."


### PR DESCRIPTION
## Summary

`download-server.sh` authenticated against the legacy Google OAuth token endpoint `https://www.googleapis.com/oauth2/v4/token`, which Google deprecated in favor of `https://oauth2.googleapis.com/token`. Reported via Zendesk #1207.

Rather than a hard swap (which would break existing self-hosted customers who only allow-list the legacy host in their network policy), this PR makes the script **try the legacy endpoint first and fall back to the current one** on connection failure.

## Changes

- **Endpoint constants** added: `legacyTokenUrl` (old) and `currentTokenUrl` (new).
- **`authenticate_gcs()`** now loops over `[legacy, current]`:
  - Sets the audience (`tokenAud`) to the endpoint being tried, rebuilds and re-signs the JWT per attempt (the `aud` claim must match the endpoint the assertion is posted to, otherwise Google rejects it), then POSTs.
  - A non-zero curl exit (connection failure / timeout, with `--connect-timeout 30`) logs a warning and falls through to the next endpoint.
  - If neither endpoint yields an access token, the script exits with a clear error.
- **`create_jwt_google_cloud()`** `aud` claim is now `"$tokenAud"` instead of the hardcoded legacy URL.
- **Deprecation warning** printed at startup (`print_deprecation_warning`): notes the legacy endpoint is deprecated, that the script falls back to the new one, and that customers should allow-list `oauth2.googleapis.com`.
- Script `version` bumped `0.1.2` → `0.1.3`.

## Why no other logic changed

The JWT-bearer grant, scope, signing, response parsing (`grep -oP '"access_token":"\K[^"]+'`) and the `storage.googleapis.com` download calls are all unaffected and fully supported on the new endpoint. Only the endpoint selection / `aud` needed to change.

## Notes for reviewers (judgment items)

- **Order is deliberate (legacy first):** preserves the working path for customers who only allow the old host today. Once they allow `oauth2.googleapis.com`, the fallback covers the deprecation transparently. If you'd prefer **new-first** (faster move off the deprecated host for customers who already allow both), say so and I'll flip the loop order.
- **`--connect-timeout 30`** added so a blocked/timing-out legacy host fails over in bounded time (the customer reported intermittent timeouts reaching `googleapis.com`). Adjust if a different bound is preferred.
- Backward-compat requires the **docs** to list the new host too. The `network-access.md` doc update (both `access_list` blocks) will be a **separate PR** on `appcircle-docusaurus`, tracked in PL-243.

## Testing

- `bash -n` passes.
- Recommend an end-to-end check with a real `cred.json`: (a) legacy-host-reachable success path, (b) legacy host blocked at the firewall → new-host fallback path.

Refs: PL-243, Zendesk #1207

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Created on behalf of berk@appcircle.io via Arc._

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved download authentication by trying both legacy and current token sources to reliably obtain an access token, even during partial service issues.
  * Added more robust handling and clearer messaging when tokens can’t be retrieved from either source.
* **Documentation**
  * Added a deprecation warning with guidance to allowlist the current host to maintain continued access.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->